### PR TITLE
croniter version needs to be updated in order to satisfy the installation requirements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ for details.
 
 Refer to irc3 documentation for more details: https://irc3.readthedocs.io/en/latest/
 
-
+TESTING
 Installation and requirements
 -----------------------------
 


### PR DESCRIPTION
When trying to install the initial requirements pip is complaining about version of croniter:

`pip install -r requirements.txt Collecting aiocron==1.3 (from -r requirements.txt (line 1)) Downloading https://files.pythonhosted.org/packages/e0/e3/054f62b98cef1576f4f6bb073c4ec86118825111502be041f277b7ac912b/aiocron-1.3-py2.py3-none-any.whl Collecting croniter==0.3.27 (from -r requirements.txt (line 2)) ERROR: Could not find a version that satisfies the requirement croniter==0.3.27 (from -r requirements.txt (line 2)) (from versions: 0.1.4.macosx-10.5-i386, 0.1.1, 0.1.2, 0.1.3, 0.1.4, 0.1.5, 0.1.6, 0.2.0, 0.2.2, 0.2.4, 0.2.5, 0.2.7, 0.3.0, 0.3.1, 0.3.2, 0.3.3, 0.3.4, 0.3.5, 0.3.6, 0.3.7, 0.3.8, 0.3.9, 0.3.10, 0.3.11, 0.3.12, 0.3.13, 0.3.14, 0.3.15, 0.3.16, 0.3.17, 0.3.18, 0.3.19, 0.3.20, 0.3.22, 0.3.23, 0.3.24, 0.3.25, 0.3.28, 0.3.29, 0.3.30, 0.3.31, 0.3.32) ERROR: No matching distribution found for croniter==0.3.27 (from -r requirements.txt (line 2))`

To resolve this the version of croniter needs to be updated in requirements.txt file.

`croniter==0.3.32`